### PR TITLE
Displays current calendar based on input field's value

### DIFF
--- a/src/jquery.nepaliDatePicker.js
+++ b/src/jquery.nepaliDatePicker.js
@@ -469,6 +469,9 @@ var calendarFunctions = {};
                         "left": inputFieldPosition.left
                     });
 
+                    if ($element.val()) {
+                        datePickerPlugin.renderFormattedSpecificDateCalendar($nepaliDatePicker, datePickerPlugin.options.dateFormat, $element.val());
+                    }
                     $nepaliDatePicker.show();
                     datePickerPlugin.eventFire($element, $nepaliDatePicker, "show");
 


### PR DESCRIPTION
Currently the calendar doesn't display the dates according to the input field after it has been initialized. The calendar displays the older data which was used to select the data from the datepicker.
This PR adds that functionality. 