### PR TITLE
Ndp-25 Fixes issue for April's date conversion during leap years

### DIFF
--- a/src/jquery.nepaliDatePicker.js
+++ b/src/jquery.nepaliDatePicker.js
@@ -330,7 +330,7 @@ var calendarFunctions = {};
                 bsDate = adDate - bsMonthFirstAdDate.getDate() + 1;
             }
 
-             //Check Leap year, add 1 day only if leap year for the month of April
+             //Check Leap year, add 1 day only for the month of April
             if (adMonth === 4 && ((adYear % 4 === 0) && (adYear % 100 !== 0)) || (adYear % 400 === 0) ) {
                 bsDate += 1
             }

--- a/src/jquery.nepaliDatePicker.js
+++ b/src/jquery.nepaliDatePicker.js
@@ -321,12 +321,18 @@ var calendarFunctions = {};
             }
 
             var bsMonthFirstAdDate = calendarFunctions.getAdDateByBsDate(bsYear, bsMonth, 1);
+                      
             if (adDate >= 1 && adDate < bsMonthFirstAdDate.getDate()) {
                 bsMonth = (bsMonth !== 1) ? bsMonth - 1 : 12;
                 var bsMonthDays = calendarFunctions.getBsMonthDays(bsYear, bsMonth);
                 bsDate = bsMonthDays - (bsMonthFirstAdDate.getDate() - adDate) + 1;
             } else {
                 bsDate = adDate - bsMonthFirstAdDate.getDate() + 1;
+            }
+
+             //Check Leap year, add 1 day only if leap year for the month of April
+            if (adMonth === 4 && ((adYear % 4 === 0) && (adYear % 100 !== 0)) || (adYear % 400 === 0) ) {
+                bsDate += 1
             }
 
             return {


### PR DESCRIPTION
For a leap year nepali-date picker showed the same date for March 31st and April 1st. So, a condition was added to ensure 1 day gets added in case of leap year during the month of April